### PR TITLE
deb: update readme with simplified build instructions for debian

### DIFF
--- a/README
+++ b/README
@@ -31,3 +31,21 @@ Those files belong to libax25, and as such, this package is marked to replace
 them. Those files will be overwritten by the ones found in the libax25-dev
 package.
 
+- Build and Install on Debian 10:
+
+        # minimum required stuff
+        sudo apt-get install devscripts build-essential lintian
+
+        # clean out old debs (will prompt)
+        rm -vi *.deb
+
+        ## LIBAX25 build/install
+        # H/T: comment on https://unix.stackexchange.com/a/416517/36152
+        (cd libax25 && mk-build-deps --install --tool 'sudo apt-get --yes --no-install-recommends' --remove && debuild -us -uc)
+        # install these now, otherwise we'll get the upstream libax25 v0.0.0 as part of tools/apps req's
+        sudo apt-get install ./libax25_*.deb ./libax25-dev*.deb
+
+        ## AX25TOOLS and APPS
+        (cd ax25tools && mk-build-deps --install --tool 'sudo apt-get --yes --no-install-recommends' --remove && debuild -us -uc)
+        (cd ax25apps && mk-build-deps --install --tool 'sudo apt-get --yes --no-install-recommends' --remove && debuild -us -uc)
+        sudo apt-get install ./ax25tools_*.deb ./ax25apps_*.deb


### PR DESCRIPTION
- improve dependency management via https://unix.stackexchange.com/a/416517/36152
- needs https://github.com/ve7fet/linuxax25/pull/11 to pull in zlib dep

@dranch this may be a simplified version of what you have in http://www.trinityos.com/HAM/Rpi-APRS-project/RPi-setup-details/rpi2-setup.txt