### PR TITLE
fix: use time_t instead of long for time variables on 32-bit ARM

### DIFF
--- a/ax25apps/listen/opentracdump.c
+++ b/ax25apps/listen/opentracdump.c
@@ -148,7 +148,7 @@ static int decode_position(unsigned char *element, int element_len)
 static int decode_timestamp(unsigned char *element, int element_len)
 {
 	/* 0x11 Timestamp - Unix format time (unsigned)  */
-	long rawtime = 0;
+	time_t rawtime = 0;
 
 	rawtime = get32(element);
 	lprintf(T_OPENTRAC, "Time: %s", ctime(&rawtime));

--- a/ax25tools/6pack/m6pack.c
+++ b/ax25tools/6pack/m6pack.c
@@ -383,7 +383,7 @@ static void sigusr1_handler(int sig)
 static void report(struct iface *tty, struct iface **pty, int numptys)
 {
 	int i;
-	long t;
+	time_t t;
 
 	time(&t);
 	syslog(LOG_INFO, "version %s.", VERSION);

--- a/ax25tools/kiss/mkiss.c
+++ b/ax25tools/kiss/mkiss.c
@@ -381,7 +381,7 @@ static void sigusr1_handler(int sig)
 static void report(void)
 {
 	int i;
-	long t;
+	time_t t;
 
 	time(&t);
 	syslog(LOG_INFO, "version %s.", VERSION);


### PR DESCRIPTION
On 32-bit ARM (armhf), time_t is 'long long int' (64-bit) but 'long' is 32-bit, causing incompatible pointer type errors when passing these variables to time(), ctime() or gmtime().

Affected files:
- ax25apps/listen/opentracdump.c: rawtime in decode_timestamp()
- ax25tools/kiss/mkiss.c: t in report()
- ax25tools/6pack/m6pack.c: t in report()

Fixes build on 32-bit ARM systems (Raspberry Pi, etc.)