### PR TITLE
fix: restore via-path parsing in parse_ax25_line() for old kernel format

### DIFF
--- a/libax25/lib/ax25/procutils.c
+++ b/libax25/lib/ax25/procutils.c
@@ -130,16 +130,45 @@ proc_ax25_t *parse_ax25_line(char *line) {
     int recv_q_idx = has_header ? 19 : 22;
     int inode_idx = has_header ? 20 : 23; 
     
-    // Extraction des données (inchangé)
-    new_conn->magic = strtoul(fields[0], NULL, 16); 
+    // Extraction des données
+    new_conn->magic = strtoul(fields[0], NULL, 16);
     strncpy(new_conn->dev, fields[1], 13); new_conn->dev[13] = '\0';
     strncpy(new_conn->src_addr, fields[2], 9); new_conn->src_addr[9] = '\0';
-    strncpy(new_conn->dest_addr, fields[3], 9); new_conn->dest_addr[9] = '\0';
-    strncpy(new_conn->digi_addr[0], fields[4], 10); new_conn->digi_addr[0][10] = '\0';
-    strncpy(new_conn->digi_addr[1], fields[5], 10); new_conn->digi_addr[1][10] = '\0';
     new_conn->ndigi = 0;
-    if (strcmp(fields[4], "*") != 0) new_conn->ndigi = 1;
-    if (strcmp(fields[5], "*") != 0) new_conn->ndigi = 2;
+    memset(new_conn->digi_addr[0], 0, sizeof(new_conn->digi_addr[0]));
+    memset(new_conn->digi_addr[1], 0, sizeof(new_conn->digi_addr[1]));
+    if (!has_header) {
+        /* Old kernel format: destination and digipeaters are grouped in a
+         * single space-delimited field, comma-separated.
+         * e.g. "OK0NAG-8,F3KT-0,OK0NAG-0" */
+        char dest_field[256];
+        strncpy(dest_field, fields[3], sizeof(dest_field) - 1);
+        dest_field[sizeof(dest_field) - 1] = '\0';
+        char *saveptr2;
+        char *part = strtok_r(dest_field, ",", &saveptr2);
+        strncpy(new_conn->dest_addr, part ? part : "*", 9);
+        new_conn->dest_addr[9] = '\0';
+        part = strtok_r(NULL, ",", &saveptr2);
+        if (part) {
+            strncpy(new_conn->digi_addr[0], part, 10);
+            new_conn->digi_addr[0][10] = '\0';
+            new_conn->ndigi = 1;
+            part = strtok_r(NULL, ",", &saveptr2);
+            if (part) {
+                strncpy(new_conn->digi_addr[1], part, 10);
+                new_conn->digi_addr[1][10] = '\0';
+                new_conn->ndigi = 2;
+            }
+        }
+    } else {
+        /* New kernel format (with header line): dest and digipeaters are
+         * in separate space-delimited fields */
+        strncpy(new_conn->dest_addr, fields[3], 9); new_conn->dest_addr[9] = '\0';
+        strncpy(new_conn->digi_addr[0], fields[4], 10); new_conn->digi_addr[0][10] = '\0';
+        strncpy(new_conn->digi_addr[1], fields[5], 10); new_conn->digi_addr[1][10] = '\0';
+        if (strcmp(fields[4], "*") != 0) new_conn->ndigi = 1;
+        if (strcmp(fields[5], "*") != 0) new_conn->ndigi = 2;
+    }
     new_conn->st = (unsigned char)atoi(fields[st_idx]);
     new_conn->vs = (unsigned short)atoi(fields[vs_idx]);
     new_conn->vr = (unsigned short)atoi(fields[vr_idx]);


### PR DESCRIPTION
## Problem

In `/proc/net/ax25` old kernel format (no header line), the destination and digipeaters are encoded as a single space-delimited field with comma separators, e.g. `OK0NAG-8,F3KT-0,OK0NAG-0`.

The refactor introduced in PR #21 broke this: `strtok_r()` with only `" \t"` delimiters treats the whole comma-separated string as one token, causing two bugs:

- `dest_addr` receives the first 9 chars **including a trailing comma** (e.g. `OK0NAG-8,`) instead of just the callsign
- Digipeaters are silently lost; `fields[4]` and `fields[5]` (which hold numeric state/vs values in old format) are wrongly stored as `digi_addr[0]` and `digi_addr[1]`

The original `read_proc_ax25()` handled this correctly by using commas as token delimiters.

## Fix

When parsing old format (`!has_header`), split `field[3]` by comma to extract `dest_addr` and up to 2 `digi_addr` entries. The new format (`has_header`) already has digipeaters in separate fields and is unchanged.

## Testing

Tested on two AX.25 nodes (F3KT and F6BVP) running Linux kernel old-format `/proc/net/ax25` with multi-hop connections through digipeaters.