### PR TITLE
libax25: fix /proc/net/ax25 header detection on 64-bit kernels

### DIFF
--- a/libax25/lib/ax25/procutils.c
+++ b/libax25/lib/ax25/procutils.c
@@ -130,16 +130,45 @@ proc_ax25_t *parse_ax25_line(char *line) {
     int recv_q_idx = has_header ? 19 : 22;
     int inode_idx = has_header ? 20 : 23; 
     
-    // Extraction des données (inchangé)
-    new_conn->magic = strtoul(fields[0], NULL, 16); 
+    // Extraction des données
+    new_conn->magic = strtoul(fields[0], NULL, 16);
     strncpy(new_conn->dev, fields[1], 13); new_conn->dev[13] = '\0';
     strncpy(new_conn->src_addr, fields[2], 9); new_conn->src_addr[9] = '\0';
-    strncpy(new_conn->dest_addr, fields[3], 9); new_conn->dest_addr[9] = '\0';
-    strncpy(new_conn->digi_addr[0], fields[4], 10); new_conn->digi_addr[0][10] = '\0';
-    strncpy(new_conn->digi_addr[1], fields[5], 10); new_conn->digi_addr[1][10] = '\0';
     new_conn->ndigi = 0;
-    if (strcmp(fields[4], "*") != 0) new_conn->ndigi = 1;
-    if (strcmp(fields[5], "*") != 0) new_conn->ndigi = 2;
+    memset(new_conn->digi_addr[0], 0, sizeof(new_conn->digi_addr[0]));
+    memset(new_conn->digi_addr[1], 0, sizeof(new_conn->digi_addr[1]));
+    if (!has_header) {
+        /* Old kernel format: destination and digipeaters are grouped in a
+         * single space-delimited field, comma-separated.
+         * e.g. "OK0NAG-8,F3KT-0,OK0NAG-0" */
+        char dest_field[256];
+        strncpy(dest_field, fields[3], sizeof(dest_field) - 1);
+        dest_field[sizeof(dest_field) - 1] = '\0';
+        char *saveptr2;
+        char *part = strtok_r(dest_field, ",", &saveptr2);
+        strncpy(new_conn->dest_addr, part ? part : "*", 9);
+        new_conn->dest_addr[9] = '\0';
+        part = strtok_r(NULL, ",", &saveptr2);
+        if (part) {
+            strncpy(new_conn->digi_addr[0], part, 10);
+            new_conn->digi_addr[0][10] = '\0';
+            new_conn->ndigi = 1;
+            part = strtok_r(NULL, ",", &saveptr2);
+            if (part) {
+                strncpy(new_conn->digi_addr[1], part, 10);
+                new_conn->digi_addr[1][10] = '\0';
+                new_conn->ndigi = 2;
+            }
+        }
+    } else {
+        /* New kernel format (with header line): dest and digipeaters are
+         * in separate space-delimited fields */
+        strncpy(new_conn->dest_addr, fields[3], 9); new_conn->dest_addr[9] = '\0';
+        strncpy(new_conn->digi_addr[0], fields[4], 10); new_conn->digi_addr[0][10] = '\0';
+        strncpy(new_conn->digi_addr[1], fields[5], 10); new_conn->digi_addr[1][10] = '\0';
+        if (strcmp(fields[4], "*") != 0) new_conn->ndigi = 1;
+        if (strcmp(fields[5], "*") != 0) new_conn->ndigi = 2;
+    }
     new_conn->st = (unsigned char)atoi(fields[st_idx]);
     new_conn->vs = (unsigned short)atoi(fields[vs_idx]);
     new_conn->vr = (unsigned short)atoi(fields[vr_idx]);
@@ -178,7 +207,20 @@ proc_ax25_t *read_proc_ax25(void) {
 
     if ((pipe_fp = popen(command, "r")) == NULL) { fprintf(stderr, "Error: Cannot open pipe for command '%s'.\n", command); return NULL; }
     if (fgets(line, sizeof(line), pipe_fp) != NULL) {
-        char *p = line; while(isspace(*p)) p++; has_header = (!isdigit(*p)); line_count = 1;
+        char *p = line; while(isspace(*p)) p++;
+        /* Detect format: old/no-header format starts with an 8-char (32-bit
+         * kernel) or 16-char (64-bit kernel) hex magic number (socket
+         * address), followed by whitespace.  A header line starts with
+         * non-hex text (e.g. "addr").
+         * We count consecutive hex digits up to 17 to distinguish:
+         *   hex_count == 8  + space at p[8]  → old 32-bit no-header format
+         *   hex_count == 16 + space at p[16] → modern 64-bit no-header format
+         * Anything else (too few or too many hex chars) → has header line. */
+        int hex_count = 0;
+        while (hex_count < 17 && isxdigit((unsigned char)p[hex_count])) hex_count++;
+        has_header = !((hex_count == 8  && isspace((unsigned char)p[8])) ||
+                       (hex_count == 16 && isspace((unsigned char)p[16])));
+        line_count = 1;
         while (fgets(line, sizeof(line), pipe_fp) != NULL) line_count++;
     }
     pclose(pipe_fp); 


### PR DESCRIPTION
## Problem

On 64-bit kernels, `/proc/net/ax25` outputs data lines starting with a **16-digit** hex socket address (e.g. `ffff888012345678 ax0 F6BVP-1 ...`). The current detection logic uses `isdigit()` on the first character, which returns `false` for hex digits `a`–`f`. As a result, `has_header` is incorrectly set to `1`, the first data line is consumed as a header, and **all AX.25 connections are silently dropped** — `read_proc_ax25()` always returns `NULL` on 64-bit systems.

This affects tools such as `axspd`, `beacon`, `mheard`, and anything else that calls `read_proc_ax25()`.

## Fix

Replace the `isdigit()` test with an exact hex-digit count:

```c
int hex_count = 0;
while (hex_count < 17 && isxdigit((unsigned char)p[hex_count])) hex_count++;
has_header = !((hex_count == 8  && isspace((unsigned char)p[8])) ||
               (hex_count == 16 && isspace((unsigned char)p[16])));
```

- `8` hex digits + whitespace → 32-bit kernel, no-header format  
- `16` hex digits + whitespace → 64-bit kernel, no-header format  
- anything else → header line present (modern kernel with column headers)

## Testing

Tested on a Raspberry Pi running a 64-bit kernel 6.x with FPAC/AX.25 stack. The working version is also published at https://github.com/f6bvp/procutils-test for reference.

Reported-by: Bernard Pidoux \<f6bvp@free.fr\>